### PR TITLE
Quick and dirty fix for winston logging empty line on Error object

### DIFF
--- a/src/start-io.js
+++ b/src/start-io.js
@@ -84,7 +84,7 @@ function ioStart() {
 const cleanExit = () => { process.exit() }
 process.on('SIGINT', cleanExit) // catch ctrl-c
 process.on('SIGTERM', cleanExit) // catch kill
-process.on('uncaughtException', log.error)
+process.on('uncaughtException', (e) => log.error(`${e.message} ${e.stack}`))
 
 // export for use by hubot
 module.exports = ioStart


### PR DESCRIPTION
This process.on('uncaughtException' -- is catching all the exceptions from both this package and the one depending on this. When combined to winston not being able to log an Error object, it makes debugging the parent project a horror. Here's a dirty and simple fix for that.

Should fix this https://github.com/kengz/spacy-nlp/issues/2