### PR TITLE
Issue-44-SIGTERM-CONTROL: Added control over SIGTERM handling by PROCESSEXIT environment variable, set NO not to exit

### DIFF
--- a/src/start-io.js
+++ b/src/start-io.js
@@ -12,6 +12,7 @@ const bashSrc = process.platform == "darwin" ? "~/.bash_profile" : "~/.bashrc";
 const srcCmd = process.env.CI ? "" : `. ${bashSrc}`;
 Promise.promisifyAll(portscanner);
 process.env.IOPORT = process.env.IOPORT || 6466;
+process.env.PROCESSEXIT =  process.env.PROCESSEXIT || "YES"; 
 
 // import other languages via child_process
 var ioClientCmds = {
@@ -90,7 +91,9 @@ function ioStart() {
 
 /* istanbul ignore next */
 const cleanExit = () => {
-  process.exit();
+  if(process.env.PROCESSEXIT === "YES"){
+    process.exit();
+  }
 };
 process.on("SIGINT", cleanExit); // catch ctrl-c
 process.on("SIGTERM", cleanExit); // catch kill


### PR DESCRIPTION
Issue-44-SIGTERM-CONTROL: Added control over SIGTERM handling by PROCESSEXIT environment variable (set NO not to call process.exit() in this package). If environment variable PROCESSEXIT is set to NO then this package would not exit when SIGTERM is called in the project (calling of process.exit() is skipped) where this package is included. Default behaviour remains the same (process.exit() is called). This way SIGTERM can be handled in the project where this package is included (if required by setting PROCESSEXIT environment variable).